### PR TITLE
refactor: 重构成svg显示，svg操作封装到SDrawUtil.js，保留原有canvas接口

### DIFF
--- a/CDrawUtil.js
+++ b/CDrawUtil.js
@@ -61,3 +61,24 @@ function canvasText(x, y, ctx, fontSize, font, color, text) {
     ctx.fillText(text, x, y);
     ctx.closePath();
 }
+
+//  绘制重心
+export function paintCenter(ctx, nodes, datas) {
+    ctx.beginPath();
+    let center = calAllCenter(nodes, datas);
+    ctx.arc(center.x, center.y, 5, 0, Math.PI*2, false);
+    ctx.fillStyle = 'green';
+    ctx.fill();
+    ctx.closePath();
+}
+//  计算重心
+function calAllCenter(nodes, datas) {
+    let x = 0, y = 0, sumE = 0;
+    for(let i = 0; i < nodes.length; ++i) {
+        x += nodes[i].x * datas[i].E;
+        y += nodes[i].y * datas[i].E;
+        sumE += datas[i].E;
+    }
+    x /= sumE, y /= sumE;
+    return {x: x, y: y};
+}

--- a/SDrawUtil.js
+++ b/SDrawUtil.js
@@ -1,0 +1,175 @@
+//  绘制所有连接节点的边
+export function paintAllLinks(nodes, edges, pad) {
+    for(let i = 0; i < edges.length; ++i) {
+        let src = nodes[edges[i].source], tar = nodes[edges[i].target];
+        svgLine(src, tar, pad, "#DAB1D5", 4, i);
+    }
+}
+//  绘制所有节点
+export function paintAllNodes(nodes, pad) {
+    nodes.forEach((node, idx) => {
+        svgPoint(node.x, node.y, pad, 'black', 5, idx);
+    });
+}
+//  绘制所有节点的文字
+export function paintAllTexts(nodes, datas, pad) {
+    nodes.forEach((node, idx) => {
+        svgText(node.x + 8, node.y - 8, pad, 16, "Georgia", "black", datas[idx].name, idx);
+    });
+}
+
+//  绘制节点、四叉树分割线、重心
+// export function dfsPaint(Nodepad, linePad, textPad, centerPad, root) {
+//     if(root.isLeaf()/* && root != this.root*/) {
+//         canvasPoint(root.centerX, root.centerY, pad, "black", 3);
+//         canvasText(root.dataX + 8, root.dataY - 8, ctx, 16, "Georgia", "black", root.data.name);
+//     }
+//     else {
+//         canvasPoint(root.centerX, root.centerY, pad, "red", 3);
+//         //  绘制四叉树的分割线
+//         svgLine({x:root.areaX + root.width / 2, y: root.areaY}, 
+//             {x:root.areaX + root.width / 2, y:root.areaY + root.height},
+//                 linePad, "#E0E0E0", 2);
+//         svgLine({x:root.areaX, y: root.areaY + root.height / 2}, 
+//             {x:root.areaX + root.width, y:root.areaY + root.height / 2},
+//                 linePad, "#E0E0E0", 2);
+//     }
+//     for(let i = 0; i < root.child.length; ++i) {
+//         if(root.child[i] != null) {
+//             dfsPaint(Nodepad, linePad, textPad, centerPad, root.child[i]);
+//         }
+//     }
+// }
+
+//  封装canvas绘制直线
+function svgLine(src, tar, pad, color, width, idx) {
+    let line = pad.oG.getElementsByTagName('line')[idx];
+    if(line != undefined) {
+        line.setAttribute('x1', src.x);
+        line.setAttribute('y1', src.y);
+        line.setAttribute('x2', tar.x);
+        line.setAttribute('y2', tar.y);
+    }
+    else {
+        line = createShape('line', {'x1':src.x, 'y1':src.y, 'x2':tar.x, 'y2':tar.y, 'stroke':color, 'stroke-width':width});
+        pad.oG.appendChild(line);  //添加到oG
+        pad.oSvg.appendChild(pad.oG);  //添加到oSvg
+        line.onmouseenter = function() {
+            startMoveLine(line, width * 1.8, width * 1.3);  //  选中动画特效
+            //...修改线的颜色
+            line.setAttribute('stroke-width', width * 1.5);
+            line.setAttribute('stroke', 'red');
+        }
+        line.onmouseleave = function() {
+            line.setAttribute('stroke-width', width);
+            line.setAttribute('stroke', color);
+        };
+    }
+}
+
+/*
+  封装canvas绘制节点
+  x,y 圆心坐标; pad为父标签集合; idx为该节点（节点或重心）索引（它们不在一个g标签内）
+*/
+function svgPoint(x, y, pad, color, radius, idx) {    //  pad {oG: , oSvg: }
+    let circle = pad.oG.getElementsByTagName('circle')[idx];
+    if(circle != undefined) {
+        circle.setAttribute('cx', x);
+        circle.setAttribute('cy', y);
+    }
+    else {
+        circle = createShape('circle', {'cx':x, 'cy':y, 'r':radius  ,'fill':color, 'stroke':'black', 'stroke-width':'1'});
+        pad.oG.appendChild(circle);  //添加到oG
+        pad.oSvg.appendChild(pad.oG);  //添加到oSvg
+        circle.onmouseenter = function() {
+            startMovePoint(pad.oG.getElementsByTagName('circle')[idx], 1.8 * radius, radius); //this是g标签 要找到圆 起始值为半径40 目标变成30
+            circle.setAttribute('fill', '#FF9224');
+            circle.setAttribute('stroke', '#FF9224');
+        }
+        circle.onmouseleave = function() {
+            circle.setAttribute('fill', color);
+            circle.setAttribute('stroke', color);
+        };
+    }
+}
+
+//  封装canvas绘制文字
+function svgText(x, y, pad, fontSize, font, color, text, idx) {
+    let oText = pad.oG.getElementsByTagName('text')[idx];
+    if(oText != undefined) {
+        oText.setAttribute('x', x);
+        oText.setAttribute('y', y);
+    }
+    else {
+        oText = createShape('text', {'x':x, 'y':y, 'fill':color, 'font-size':fontSize, 'text-anchor':'middle' });
+        oText.innerHTML = text;  //添加文字
+        pad.oG.appendChild(oText);  //添加到oG
+        pad.oSvg.appendChild(pad.oG);  //添加到oSvg
+    }
+}
+
+//  绘制重心
+export function paintCenter(pad, nodes, datas, idx) {
+    let center = calAllCenter(nodes, datas);
+    svgPoint(center.x, center.y, pad, 'green', 5, idx);
+}
+//  计算重心
+function calAllCenter(nodes, datas) {
+    let x = 0, y = 0, sumE = 0;
+    for(let i = 0; i < nodes.length; ++i) {
+        x += nodes[i].x * datas[i].E;
+        y += nodes[i].y * datas[i].E;
+        sumE += datas[i].E;
+    }
+    x /= sumE, y /= sumE;
+    return {x: x, y: y};
+}
+
+export function createShape(tag, objAttr) {       //封装一个创建标签的函数 这里取名为createTag
+    let svgNS = 'http://www.w3.org/2000/svg';   //命名空间
+    let oTag = document.createElementNS(svgNS, tag);
+    for(let attr in objAttr){
+       oTag.setAttribute(attr, objAttr[attr]);    //设置属性
+    }
+    return oTag;
+}
+
+//鼠标移入移出时的弹性变化
+function startMovePoint(obj, r1, r2) {
+    var nowR = r1;
+    var overR = r2;
+    obj.speed = 0;
+    clearInterval(obj.timer);
+    obj.timer = setInterval(function(){
+        obj.speed += (overR - nowR) / 6;
+        obj.speed *= 0.8; //摩擦系数
+        if(Math.abs(overR - nowR) <= 1 && Math.abs(obj.speed) <= 1) {
+            clearInterval(obj.timer);
+            obj.setAttribute('r', overR);
+        }
+        else{
+            nowR += obj.speed;
+            obj.setAttribute('r', nowR);
+        }
+    }, 30);
+}
+
+//鼠标移入移出时的弹性变化
+function startMoveLine(obj, r1, r2) {
+    var nowR = r1;
+    var overR = r2;
+    obj.speed = 0;
+    clearInterval(obj.timer);
+    obj.timer = setInterval(function(){
+        obj.speed += (overR - nowR) / 6;
+        obj.speed *= 0.8; //摩擦系数
+        if(Math.abs(overR - nowR) <= 1 && Math.abs(obj.speed) <= 1) {
+            clearInterval(obj.timer);
+            obj.setAttribute('stroke-width', overR);
+        }
+        else{
+            nowR += obj.speed;
+            obj.setAttribute('stroke-width', nowR);
+        }
+    }, 30);
+}

--- a/canvasMain.js
+++ b/canvasMain.js
@@ -1,8 +1,8 @@
 import QuadTree from "./QuadTree.js";
 import ManyBody from "./manyBody.js";
 import {judge, choose, caldis, getNodePair} from "./stop.js" ;
-import {paintCenter, getNodePos, getTree, nwk2json, randomNum, initTreeShape} from "./util.js";
-import {paintAllLinks, dfsPaint} from "./DrawUtil.js";
+import {getNodePos, getTree, nwk2json, randomNum, initTreeShape} from "./util.js";
+import {paintAllLinks, paintCenter, dfsPaint} from "./CDrawUtil.js";
 
 // var nodes = [{x:100, y:100}, {x:200, y:130}, {x:800, y:400}, {x:900, y:500}, {x:900, y:50}];
 // var nodes = [getNodePos(), getNodePos(), getNodePos(), getNodePos(), getNodePos()];

--- a/svgMain.js
+++ b/svgMain.js
@@ -1,0 +1,64 @@
+import ManyBody from "./manyBody.js";
+import {judge, choose, caldis, getNodePair} from "./stop.js" ;
+import {getTree, nwk2json, initTreeShape} from "./util.js";
+import {paintAllLinks, paintAllNodes, paintAllTexts, createShape} from "./SDrawUtil.js";
+
+var svgNS = 'http://www.w3.org/2000/svg';   //命名空间
+var oParent = document.getElementById("svg");   //获取父节点 才能添加到页面中
+var centerX = oParent.offsetWidth/2;   //中心点横坐标
+var centerY = oParent.offsetHeight/2;   //中心点纵坐标
+
+var oG_Node = createShape('g', {'style':'cursor:pointer', 'class':'circleStyle'});  //  鼠标悬浮在形状上时为手指icon
+var oG_Line = createShape('g', {'style':'cursor:pointer', 'class':'lineStyle'});
+var oG_Text = createShape('g', {'style':'cursor:pointer', 'class':'textStyle'});
+var oSvg = createShape('svg', {'xmlns':svgNS, 'width':'100%', 'height':'100%' });
+
+oParent.appendChild(oSvg);  //添加到oParent
+
+var pad_Node = {oG: oG_Node, oSvg: oSvg};
+var pad_Link = {oG: oG_Line, oSvg: oSvg};
+var pad_Text = {oG: oG_Text, oSvg: oSvg};
+
+let info = nwk2json('(A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5)F');
+// let info = nwk2json('((C:0.3,D:0.4)E:0.1)F');
+let tree = getTree(info);
+console.log(tree);
+var nodes = initTreeShape(info, 1000, 600), edges = tree.edges, datas = tree.datas;
+
+var manyBody = new ManyBody(null, 1000, 600);
+manyBody.nodes = nodes, manyBody.datas = datas, manyBody.edges = edges;
+manyBody.buildTree();
+
+var pairName = choose(edges, datas), pair = [];
+var record = 0;
+
+// iter();
+
+setInterval(function(){
+    paintAmimation();
+    paintAllLinks(manyBody.nodes, manyBody.edges, pad_Link);
+    paintAllNodes(manyBody.nodes, pad_Node);
+    paintAllTexts(manyBody.nodes, manyBody.datas, pad_Text);
+}, 1);
+
+function iter() {
+    while(1) {
+        manyBody.buildTree();
+        //  判断形状收敛，退出迭代
+        pair = getNodePair(pairName, manyBody.quadTree);
+        if(judge(pair, record))
+            return;
+        record = caldis(pair);
+        manyBody.step();
+    }
+}
+
+function paintAmimation() {
+    manyBody.buildTree();
+    //  判断形状收敛，退出迭代
+    pair = getNodePair(pairName, manyBody.quadTree);
+    if(judge(pair, record))
+        return;
+    record = caldis(pair);
+    manyBody.step();
+}

--- a/svgSample.html
+++ b/svgSample.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<style>
+#div1 {width:780px; height:400px; background:url(img/bg.jpg) no-repeat;  margin:20px auto; overflow:hidden; }
+body {background:black; }
+</style>
+<script>
+
+// <!--svg中创建标签的方法-->
+window.onload=function(){
+  var svgNS='http://www.w3.org/2000/svg';   //命名空间
+  var oParent=document.getElementById('div1');   //获取父节点 才能添加到页面中
+  var centerX=oParent.offsetWidth/2;   //中心点横坐标
+  var centerY=oParent.offsetHeight/2;   //中心点纵坐标
+
+  var circleNum=9;
+  var angleNum=360/circleNum;
+  var centerR=150;
+  var otherData=[];
+
+  for(var i=0;i<circleNum;i++){
+    var x=Math.cos(i*40*Math.PI/180)*centerR+centerX;
+    var y=Math.sin(i*40*Math.PI/180)*centerR+centerY;
+    otherData.push({x:x, y:y, text:i });
+  }
+
+//数据与操作分离
+  var data={
+    centerNode: {text:'心情如何'},
+    otherNode: otherData,
+  };
+
+  function createTag(tag, objAttr){       //封装一个创建标签的函数 这里取名为createTag
+      var oTag=document.createElementNS(svgNS, tag);
+      for(var attr in objAttr){
+         oTag.setAttribute(attr, objAttr[attr]);    //设置属性
+      }
+      return oTag;
+  }
+  
+//中间圆
+  function addTag(){
+     var oSvg=createTag('svg', {'xmlns':svgNS, 'width':'100%', 'height':'100%' });
+     
+     for(var i=0;i<data.otherNode.length;i++){
+        addOtherTag(data.otherNode[i], oSvg);
+     }
+
+     var oG=createTag('g', {'style':'cursor:pointer'});
+     var oCircle=createTag('circle', {'cx':centerX, 'cy':centerY, 'r':'40'  ,'fill':'white', 'stroke':'red', 'stroke-width':'1'});
+     var oText=createTag('text', {'x':centerX, 'y':centerY+8, 'font-size':'20', 'text-anchor':'middle' });
+     oText.innerHTML=data.centerNode.text;
+
+     oG.appendChild(oCircle);  //添加到oG
+     oG.appendChild(oText);  //添加到oG
+     oSvg.appendChild(oG);  //添加到oSvg
+     oParent.appendChild(oSvg);  //添加到oParent
+  }
+  //调用一下
+  addTag();
+
+//其他圆和线
+  function addOtherTag(otherAttr, oSvg){
+   //创建线
+    var oG=createTag('g', {'style':'cursor:pointer', 'class':'lineStyle'});
+    var oLine1=createTag('line', {'x1':otherAttr.x, 'y1':otherAttr.y, 'x2':centerX, 'y2':centerY, 'stroke':'#ccc'});
+    var oLine2=createTag('line', {'x1':otherAttr.x, 'y1':otherAttr.y, 'x2':centerX, 'y2':centerY, 'stroke':'transparent', 'stroke-width':'10'});
+    var oRect=createTag('rect', {'x':(centerX+otherAttr.x)/2-10, 'y':(centerY+otherAttr.y)/2-10, 'fill':'#999', 'width':'20', 'height':'20', 'rx':'5'});
+    var oText=createTag('text', {'x':(centerX+otherAttr.x)/2, 'y':(centerY+otherAttr.y)/2+8, 'fill':'white', 'font-size':'20', 'text-anchor':'middle' });
+    oText.innerHTML='?';  //添加文字
+
+    oG.appendChild(oLine1);  //添加到oG
+    oG.appendChild(oLine2);  //添加到oG
+    oG.appendChild(oRect);  //添加到oG
+    oG.appendChild(oText);  //添加到oG
+    oSvg.appendChild(oG);  //oG添加到oSvg
+  
+   //创建圆 
+    var oG=createTag('g', {'style':'cursor:pointer', 'class':'circleStyle'});
+    var oCircle=createTag('circle', {'cx':otherAttr.x, 'cy':otherAttr.y, 'r':'30'  ,'fill':'white', 'stroke':'red', 'stroke-width':'1'});
+    var oText=createTag('text', {'x':otherAttr.x, 'y':otherAttr.y+8, 'font-size':'20', 'text-anchor':'middle' });
+    oText.innerHTML=otherAttr.text; //文字是传过来的otherAttr的text
+
+    oG.appendChild(oCircle);  //添加到oG
+    oG.appendChild(oText);  //添加到oG
+    oSvg.appendChild(oG);  //添加到oSvg
+  }
+
+
+  bindTag();
+
+  function bindTag(){
+    var aLine=document.getElementsByClassName('lineStyle');
+    var aCircle=document.getElementsByClassName('circleStyle');
+    for(var i=0;i<aCircle.length;i++){
+      aCircle[i].onmouseenter=function(){
+        startMove(this.getElementsByTagName('circle')[0], 30 ,40); //this是g标签 要找到圆 起始值为半径30 目标变成40
+
+        var prevLine=this.previousElementSibling;         //获取上一个标签 此时为线的g标签
+        prevLine.getElementsByTagName('line')[0].setAttribute('stroke','blue');  //修改线为蓝色
+        prevLine.getElementsByTagName('rect')[0].setAttribute('fill','red');  //修改方块为红色
+
+      };
+      aCircle[i].onmouseleave=function(){
+        startMove(this.getElementsByTagName('circle')[0], 40 ,30); //this是g标签 要找到圆 起始值为半径40 目标变成30
+
+        var prevLine=this.previousElementSibling;         //获取上一个标签 此时为线的g标签
+        prevLine.getElementsByTagName('line')[0].setAttribute('stroke','#ccc');  //修改线为蓝色
+        prevLine.getElementsByTagName('rect')[0].setAttribute('fill','#999');  //修改方块为红色
+
+      };
+    }
+    for(var i=0;i<aLine.length;i++){
+      aLine[i].onmouseenter=function(){
+        this.getElementsByTagName('line')[0].setAttribute('stroke','blue');  //修改线为蓝色
+        this.getElementsByTagName('rect')[0].setAttribute('fill','red');  //修改方块为红色
+
+        var prevCircle=this.nextElementSibling;         //获取下一个标签 此时为圆的g标签
+        startMove(prevCircle.getElementsByTagName('circle')[0], 30 ,40); //this是g标签 要找到圆 起始值为半径40 目标变成30
+
+      };
+      aLine[i].onmouseleave=function(){
+        this.getElementsByTagName('line')[0].setAttribute('stroke','#ccc');  //修改线为蓝色
+        this.getElementsByTagName('rect')[0].setAttribute('fill','#999');  //修改方块为红色
+
+        var prevCircle=this.nextElementSibling;         //获取下一个标签 此时为圆的g标签
+        startMove(prevCircle.getElementsByTagName('circle')[0], 40 ,30); //this是g标签 要找到圆 起始值为半径40 目标变成30
+
+      };
+    }
+
+  }
+
+  //鼠标移入移出时的弹性变化
+  function startMove(obj, r1, r2){
+    var nowR=r1;
+    var overR=r2;
+    obj.speed=0;
+    clearInterval(obj.timer);
+    obj.timer=setInterval(function(){
+      obj.speed+=(overR-nowR)/6;
+      obj.speed*=0.9; //摩擦系数
+      if(Math.abs(overR-nowR)<=1 && Math.abs(obj.speed)<=1){
+        clearInterval(obj.timer);
+        obj.setAttribute('r', overR);
+      }
+      else{
+        nowR +=obj.speed;
+        obj.setAttribute('r', nowR);
+      }
+    },30);
+  }
+
+}  
+</script>
+</head>
+<body>
+<!--直接写svg的方法-->
+<div id="div1">
+
+</div>
+</body>
+</html>

--- a/svgShow.html
+++ b/svgShow.html
@@ -7,7 +7,12 @@
     <title>Document</title>
 </head>
 <body>
-    <canvas id="canvas" width="1000" height="600"></canvas> 
-    <script type="module" src="./canvasMain.js"></script>
+    <div id="svg"></div>
+    <script type="module" src="./svgMain.js"></script>
 </body>
 </html>
+
+<style>
+    #svg {width:1000px; height:600px;  margin:20px auto; overflow:hidden; }
+    body {background:rgb(255, 255, 255); }
+</style>

--- a/util.js
+++ b/util.js
@@ -9,26 +9,6 @@ export function randomNum(minNum, maxNum){
             return 0; 
     } 
 } 
-//  绘制重心
-export function paintCenter(ctx, nodes, datas) {
-    ctx.beginPath();
-    let center = calAllCenter(nodes, datas);
-    ctx.arc(center.x, center.y, 5, 0, Math.PI*2, false);
-    ctx.fillStyle = 'green';
-    ctx.fill();
-    ctx.closePath();
-}
-//  计算重心
-function calAllCenter(nodes, datas) {
-    let x = 0, y = 0, sumE = 0;
-    for(let i = 0; i < nodes.length; ++i) {
-        x += nodes[i].x * datas[i].E;
-        y += nodes[i].y * datas[i].E;
-        sumE += datas[i].E;
-    }
-    x /= sumE, y /= sumE;
-    return {x: x, y: y};
-}
 
 export function getNodePos(width = 1000, height = 600) {
     return {x: randomNum(0, width), y: randomNum(0, height)};


### PR DESCRIPTION
svgSample.html是学习svg的demo，暂时不删；原有canvas实现的drawUtil和main重命名