### PR TITLE
fix: 初始化树形bug修复的失败尝试

### DIFF
--- a/util.js
+++ b/util.js
@@ -129,12 +129,15 @@ export function initTreeShape(tree, width=1000, height=600) {
 		nodes.push(now.pos);
         que.shift();
         if(now.node.children != undefined) { //  是非叶子节点
-			let childrenList = [], leafList = [];
+			let childrenList = [];
 			now.node.children.forEach(child => {
 				if(child != undefined)
 					childrenList.push(child);
 			});
 			let nowAlpha = 0.0, subAlpha = 2 * Math.PI / (childrenList.length + 1);// + 0.05 / (2 * Math.PI);
+			if(now.node == tree) {
+				// subAlpha = 2 * Math.PI / (childrenList.length + 0);
+			}
 			childrenList.forEach(child => {
 				nowAlpha += subAlpha;
 				let tmpAlpha = Math.PI - now.alpha + nowAlpha;


### PR DESCRIPTION
原先树形初始化没有特判根，导致最初树形不符预期。但特判后虽形状正确，但某2相邻节点加速靠近导致模拟紊乱崩溃，尚未找到原因